### PR TITLE
Add close modal after save data if everything is ok

### DIFF
--- a/frontend/entry/modal.js
+++ b/frontend/entry/modal.js
@@ -103,6 +103,8 @@ window.Erste.modal = new Vue({
             text: 'Se ha guardado el auxilio en el sistema.',
             type: 'success',
           });
+          // close modal after submit if no errors
+          this.$modal.hide('incident-modal');
         })
         .catch(() => {
           this.$notify({


### PR DESCRIPTION
Fix, close modal after save data, actually if you press save many times and no click outside the modal the modal don't close and the new incident is created as many times the user press save incident